### PR TITLE
Fixes warning message setting non-blocking mode on invalid resource

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -325,9 +325,11 @@ class Command
         }
 
         // Setup all streams to non-blocking mode
-        stream_set_blocking($pipes[self::STDIN], false);
-        stream_set_blocking($pipes[self::STDOUT], false);
-        stream_set_blocking($pipes[self::STDERR], false);
+        foreach ($pipes as $pipe) {
+            if (is_resource($pipe)) {
+                stream_set_blocking($pipe, false);
+            }
+        }
 
         $stream_select_timeout_sec = null;
         $stream_select_timeout_usec = null;


### PR DESCRIPTION
Fixes a warning message displayed when try to set a non-blocking mode on an invalid resource.

`PHP Warning:  stream_set_blocking(): 9 is not a valid stream resource in /code/command/src/Command.php on line 328`

To reproduce run `examples/callback.php`
